### PR TITLE
remove `extends Promise<T>` from RedditContent

### DIFF
--- a/src/objects/RedditContent.d.ts
+++ b/src/objects/RedditContent.d.ts
@@ -1,6 +1,6 @@
 import * as Snoowrap from '../snoowrap';
 
-export default class RedditContent<T> extends Promise<T> {
+export default class RedditContent<T> {
   created_utc: number;
   created: number;
   id: string;

--- a/src/snoowrap.d.ts
+++ b/src/snoowrap.d.ts
@@ -71,7 +71,7 @@ declare class Snoowrap {
   getInbox(options?: { filter?: string }): Promise<_Listing<_PrivateMessage | _Comment>>;
   getKarma(): Promise<Array<{ sr: _Subreddit; comment_karma: number; link_karma: number; }>>;
   getLivethread(threadId: string): _LiveThread;
-  getMe(): _RedditUser;
+  getMe(): Promise<_RedditUser>;
   getMessage(messageId: string): _PrivateMessage;
   getModeratedSubreddits(options?: ListingOptions): Promise<_Listing<_Subreddit>>;
   getModmail(options?: ListingOptions): Promise<_Listing<_PrivateMessage>>;
@@ -103,7 +103,7 @@ declare class Snoowrap {
   getSubscriptions(options?: ListingOptions): _Listing<_Subreddit>;
   getTop(subredditName?: string, options?: SortedListingOptions): Promise<_Listing<_Submission>>;
   getUnreadMessages(options?: ListingOptions): Promise<_Listing<_PrivateMessage>>;
-  getUser(name: string): _RedditUser;
+  getUser(name: string): Promise<_RedditUser>;
   markAsVisited(links: _Submission[]): Promise<void>;
   markMessagesAsRead(messages: _PrivateMessage[] | string[]): Promise<void>;
   markMessagesAsUnread(messages: _PrivateMessage[] | string[]): Promise<void>;


### PR DESCRIPTION
Reddit content should be the body of a promise, not an extension of a promise. This addresses #221 and enables

```typescript
const user = await snoowrap.getUser()
```